### PR TITLE
gitpanda: requires Go 1.23.4

### DIFF
--- a/.github/workflows/upgrade_go.yml
+++ b/.github/workflows/upgrade_go.yml
@@ -29,7 +29,7 @@ jobs:
             go_version: "1.23"
 
           - repo: "sue445/gitpanda"
-            go_version: "1.23"
+            go_version: "1.23.4"
 
           - repo: "sue445/plant_erd"
             go_version: "1.23"


### PR DESCRIPTION
https://github.com/sue445/gitpanda/pull/1661

gitlab.com/gitlab-org/api/client-go requires Go 1.23.4

c.f. https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/2091